### PR TITLE
Autocomplete via MetaCPAN over HTTPS

### DIFF
--- a/html/NoAuth/js/rt.cpan.org.js
+++ b/html/NoAuth/js/rt.cpan.org.js
@@ -46,7 +46,7 @@ jQuery(function(){
                 // Adaptive autocomplete!  If the term contains a colon, look
                 // for modules and map to distributions via metacpan.
                 this_request = current_request = jQuery.ajax({
-                    url: "http://api.metacpan.org/v0/search/autocomplete",
+                    url: "https://api.metacpan.org/v0/search/autocomplete",
                     dataType: "json",
                     data: {
                         q: request.term


### PR DESCRIPTION
Otherwise Firefox (at least v31.0) blocks the request because
rt.cpan.org is served over HTTPS.  Chrome was unaffected.

Reported on perl5-porters in
<CA+vYcVxy+DLJfs1XDVabrMrOqBxwis4dDX7PGQMBd_x_grPMxQ@mail.gmail.com>
