### PR TITLE
Update default queue addresses to match the host

### DIFF
--- a/etc/CPAN_Config.pm
+++ b/etc/CPAN_Config.pm
@@ -18,8 +18,8 @@ Set( $AutocompleteOwnersForSearch, 1 );
 Set( $UsernameFormat, 'public' );
 
 # Email defaults; queues get their own dynamic addresses too
-Set( $CorrespondAddress, 'bugs@rt.cpan.org' );
-Set( $CommentAddress,    'comments@rt.cpan.org' );
+Set( $CorrespondAddress, 'bug@rt.cpan.org' );
+Set( $CommentAddress,    'comment@rt.cpan.org' );
 
 # The old $rtname used to be "cpan"; accept it.
 # See also BugTracker_Config.pm which extends this variable.


### PR DESCRIPTION
This commit updates the RT CPAN extension config to match
CorrespondAddress and CommentAddress as they're set on the host.